### PR TITLE
Update grpc and protocol-buffers-schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,11 +120,6 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "arguejs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
-      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
-    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -1234,19 +1229,18 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.6.0.tgz",
-      "integrity": "sha1-LWN9HligPFMOvJvC3WwTXCTBIs8=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.9.0.tgz",
+      "integrity": "sha512-F4j7ireH/ssXcBNTGR3yFjRHTWdJmtg6Czm5tnQYwIuhZh4znx8KhA50dpAkjNqrrbzt97N6hd/TXOPTZGmvtQ==",
       "requires": {
-        "arguejs": "0.2.3",
-        "lodash": "4.17.4",
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36",
+        "lodash": "4.17.5",
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
         "ajv": {
@@ -1262,7 +1256,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.1.2",
+          "version": "1.2.0",
           "bundled": true
         },
         "are-we-there-yet": {
@@ -1379,7 +1373,7 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
           "requires": {
             "ms": "2.0.0"
@@ -1395,6 +1389,10 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
           "bundled": true
         },
         "ecc-jsbn": {
@@ -1423,7 +1421,7 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
-            "mime-types": "2.1.16"
+            "mime-types": "2.1.17"
           }
         },
         "fs.realpath": {
@@ -1437,7 +1435,7 @@
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "fstream-ignore": {
@@ -1453,7 +1451,7 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.1.2",
+            "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
             "has-unicode": "2.0.1",
             "object-assign": "4.1.1",
@@ -1544,7 +1542,7 @@
           "bundled": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true
         },
         "is-fullwidth-code-point": {
@@ -1606,15 +1604,20 @@
             }
           }
         },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
         "mime-db": {
-          "version": "1.29.0",
+          "version": "1.30.0",
           "bundled": true
         },
         "mime-types": {
-          "version": "2.1.16",
+          "version": "2.1.17",
           "bundled": true,
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "1.30.0"
           }
         },
         "minimatch": {
@@ -1625,7 +1628,7 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
+          "version": "0.0.8",
           "bundled": true
         },
         "mkdirp": {
@@ -1633,12 +1636,6 @@
           "bundled": true,
           "requires": {
             "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
           }
         },
         "ms": {
@@ -1646,25 +1643,27 @@
           "bundled": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "requires": {
+            "detect-libc": "1.0.3",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.1",
+            "rc": "1.2.4",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.4.1",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
             "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "tar-pack": "3.4.1"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.0",
+            "abbrev": "1.1.1",
             "osenv": "0.1.4"
           }
         },
@@ -1734,13 +1733,19 @@
           "bundled": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.4",
           "bundled": true,
           "requires": {
             "deep-extend": "0.4.2",
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "readable-stream": {
@@ -1773,19 +1778,19 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.16",
+            "mime-types": "2.1.17",
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "requires": {
             "glob": "7.1.2"
@@ -1796,7 +1801,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.4.1",
+          "version": "5.5.0",
           "bundled": true
         },
         "set-blocking": {
@@ -1875,21 +1880,21 @@
           }
         },
         "tar-pack": {
-          "version": "3.4.0",
+          "version": "3.4.1",
           "bundled": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "fstream": "1.0.11",
             "fstream-ignore": "1.0.5",
             "once": "1.4.0",
             "readable-stream": "2.3.3",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "tar": "2.2.1",
             "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
             "punycode": "1.4.1"
@@ -1916,7 +1921,7 @@
           "bundled": true
         },
         "uuid": {
-          "version": "3.1.0",
+          "version": "3.2.1",
           "bundled": true
         },
         "verror": {
@@ -2821,7 +2826,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -3077,9 +3083,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3430,9 +3436,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.1.tgz",
-      "integrity": "sha1-rRURQYd8aviChkeFGvZqDbaSdfU="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
     },
     "proxy-addr": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "body-parser": "^1.16.0",
     "colors": "^1.1.2",
     "express": "^4.14.0",
-    "grpc": "^1.6.0",
-    "protocol-buffers-schema": "^3.3.1",
+    "grpc": "^1.9.0",
+    "protocol-buffers-schema": "^3.3.2",
     "yargs": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed an issue that does not start if we have the following option.

```
service LoginService {
  rpc Login(LoginRequest) returns(LoginResponse) {
    option (google.api.http) = {
      post: "/login",
      body: "*" // <- here
    };
  }
```