### PR TITLE
Features/pass protofile

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const middleware = (protoFiles, grpcLocation, credentials = requiredGrpc.credent
     .forEach((sch, si) => {
       const pkg = sch.package
       clients[pkg] = clients[pkg] || {}
+      if(!sch.services){return;}
       sch.services.forEach(s => {
         const svc = s.name
         clients[pkg][svc] = new protos[si][pkg][svc](grpcLocation, credentials)

--- a/index.js
+++ b/index.js
@@ -22,6 +22,15 @@ const lowerFirstChar = str => str.charAt(0).toLowerCase() + str.slice(1)
 const middleware = (protoFiles, grpcLocation, credentials = requiredGrpc.credentials.createInsecure(), debug = true, include, grpc = requiredGrpc) => {
   const router = express.Router()
   const clients = {}
+  if(include.endsWith("/")) {
+    include = include.substring(0, include.length-1); // remove"/"
+  }
+  protoFiles = protoFiles.map(function (value, index, array) {
+    if(value.startsWith(include)){
+      value = value.substring(include.length + 1);
+      return value;
+    }
+  });
   const protos = protoFiles.map(p => include ? grpc.load({file: p, root: include}) : grpc.load(p))
   protoFiles
     .map(p => `${include}/${p}`)


### PR DESCRIPTION
- Fixed problem that does not start if there is no service
- Changed how to pass the proto file
```
docker run --rm -v $(pwd):$(pwd) \
 -p $(GRPC_DYNAMIC_GATEWAY_PORT):$(GRPC_DYNAMIC_GATEWAY_PORT) \
 --init \
 konsumer/grpc-dynamic-gateway \
 --grpc $(GRPC_HOST):$(GRPC_PORT) \
 --port=$(GRPC_DYNAMIC_GATEWAY_PORT) \
 -I $(pwd)/proto/ $(pwd)/proto/*.proto
```
**You need to put the file of google/api/*.proto and google/protobuf/*.proto under $(pwd)/proto**