### PR TITLE
protoc-gen-swagger has been renamed to protoc-gen-openapiv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ const credentials = grpc.credentials.createSsl(
 app.use('/', grpcGateway(['api.proto'], '0.0.0.0:5051', credentials))
 ```
 
-# swagger
+# OpenAPI (a.k.a Swagger)
 
-[Protoc](https://github.com/google/protobuf) can generate a swagger description of your RPC endpoints, if you have [protoc-gen-swagger](https://github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger) installed:
+[Protoc](https://github.com/google/protobuf) can generate a OpenAPI description of your RPC endpoints, if you have [protoc-gen-openapiv2](https://github.com/grpc-ecosystem/grpc-gateway/tree/master/protoc-gen-openapiv2) installed:
 
 ```
-protoc DEFINITION.proto --swagger_out=logtostderr=true:.
+protoc DEFINITION.proto --openapiv2_out=logtostderr=true:.
 ```
 
 # docker


### PR DESCRIPTION
See https://github.com/grpc-ecosystem/grpc-gateway/commit/2ee1c8c31112562852b88ece31fa9b0b8d074ca5#diff-66cbdfa72b31c2891b092d690049d61a844af99efca89b01ae8ce64a4cc9c1fe